### PR TITLE
feat: parse extensions

### DIFF
--- a/gpxfix/__init__.py
+++ b/gpxfix/__init__.py
@@ -1,2 +1,2 @@
 name = "gpxfix"
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="jannis.born@gmx.de",
     url="https://github.com/jannisborn/gpxfix",
     license="MIT",
-    install_requires=["numpy", "gpxpy", "matplotlib"],
+    install_requires=["numpy", "gpxpy>=1.3.5", "matplotlib"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Extensions in the `gpx` files (e.g., heartrate, atemp etc) are no longer stripped off, but are now copied into the repaired file